### PR TITLE
docs(readme): add USDT Payment example and fix Transaction args decimal scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,56 @@ export const PaymentBasic = () => {
 };
 ```
 
+### Example with USDT
+
+USDT on Celo uses 6 decimals. Pass the amount as a human-readable string (e.g. `"1.5"`) — the `Payment` component handles unit conversion internally using the token's decimals. Use the USDT token address, not the cUSD address.
+
+```tsx
+import { useState } from "react";
+import { Payment, PaymentError, PaymentDialog } from "@composer-kit/ui/payment";
+import { celo } from "viem/chains";
+
+// USDT on Celo mainnet — 6 decimals
+const USDT_ADDRESS = "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e";
+
+export const PaymentUSDT = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [txHash, setTxHash] = useState("");
+
+  return (
+    <div className="w-full items-center justify-center flex flex-col gap-4">
+      <Payment
+        amount="1.5"
+        //@ts-ignore
+        chain={celo}
+        onSuccess={(hash) => {
+          setTxHash(hash);
+          setIsOpen(false);
+        }}
+        onError={(error) => {
+          console.error("Payment error", error);
+        }}
+        recipientAddress="0x717F8A0b80CbEDe59EcA195F1E3D8E142C84d4d6"
+        tokenAddress={USDT_ADDRESS}
+      >
+        <button
+          className="bg-black font-medium dark:bg-white text-white dark:text-black px-4 py-2 rounded"
+          onClick={() => setIsOpen(!isOpen)}
+        >
+          Pay 1.5 USDT
+        </button>
+        <PaymentDialog
+          onOpenChange={() => setIsOpen(!isOpen)}
+          open={isOpen}
+        />
+        <PaymentError />
+      </Payment>
+      {txHash && <p>{txHash}</p>}
+    </div>
+  );
+};
+```
+
 ## Swap
 
 The `Swap` component allows users to exchange tokens seamlessly with a simple interface.
@@ -489,8 +539,11 @@ export const TransactionBasic = () => {
               outputs: [{ name: "", type: "bool" }],
             },
           ],
+          // cUSD on Celo mainnet (18 decimals)
+          // To send 1 cUSD: use 1_000_000_000_000_000_000n (18 decimal places)
+          // To send 1 USDT (0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e): use 1_000_000n (6 decimal places)
           address: "0x765de816845861e75a25fca122bb6898b8b1282a",
-          args: ["0x717F8A0b80CbEDe59EcA195F1E3D8E142C84d4d6", 1],
+          args: ["0x717F8A0b80CbEDe59EcA195F1E3D8E142C84d4d6", 1_000_000_000_000_000_000n],
           functionName: "transfer",
         }}
       >


### PR DESCRIPTION
## What changed

**`README.md`** — one commit, two targeted fixes

### Fix 1: Transaction example `args` decimal clarification
The existing `Transaction` example passes `args: ["0x717...", 1]` — a raw `uint256` value of `1`. For cUSD (18 decimals) this is `0.000000000000000001 cUSD`, not `1 cUSD`. This is misleading for any developer copying the example.

Changed to `1_000_000_000_000_000_000n` (1 cUSD in wei) and added inline comments explaining:
- How to scale for cUSD (18 decimals)
- How to scale for USDT (`0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e`, 6 decimals → `1_000_000n`)

### Fix 2: Add USDT `Payment` example
The `Payment` section has one example using cUSD. The `Identity` props table already lists `token: "CELO" | "cUSD" | "USDT"` showing USDT is a supported token type, but there is no `Payment` example showing how to use it.

Added a `### Example with USDT` subsection immediately after the existing `PaymentBasic` example with:
- USDT mainnet address as a named constant with a decimal comment
- Complete working `PaymentUSDT` component following the exact same pattern as `PaymentBasic`
- A one-line explanation that `amount` is passed as a human-readable string

## Why

The `Transaction` example with `args: [address, 1]` is the kind of mistake that causes real fund loss — a developer copying it and substituting their own token address would send a transaction that appears to succeed but transfers a negligible amount. The corrected value makes the scaling requirement explicit.

The USDT `Payment` example closes a gap between the props documentation (which mentions USDT) and the usage examples (which only show cUSD).

## How to verify

1. Search for `1_000_000_000_000_000_000n` in `README.md` — should appear in the Transaction example with accompanying decimal comments
2. Search for `PaymentUSDT` — the complete component should appear under `### Example with USDT`
3. Search for `48065fbBE` — USDT address should appear in both the Transaction comment and the PaymentUSDT constant
4. USDT address verified at celoscan.io/token/0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e